### PR TITLE
Override top left logo styles from core-resource

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -5,6 +5,12 @@ html, body {
     font-size: 9pt;
 }
 
+#header #headerBanner {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
 .not-for-screen {
     display: none;
 }


### PR DESCRIPTION
As we are close to release and we don't know what apps need the existing styles for the logo to appear correctly from core-resource-app so we override it here and in one other affected applications.